### PR TITLE
Use validation set for evaluation

### DIFF
--- a/examples/python-guide/advanced_example.py
+++ b/examples/python-guide/advanced_example.py
@@ -202,7 +202,7 @@ def reset_metrics():
 gbm = lgb.train(params,
                 lgb_train,
                 num_boost_round=10,
-                valid_sets=lgb_train,
+                valid_sets=lgb_eval,
                 callbacks=[reset_metrics()])
 
 print('Finished first 10 rounds with callback function...')


### PR DESCRIPTION
I noticed that at the very end of the example, you were using the training set for both training and validation, probably because of a typo.